### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker.arvados-cli.RocheCert.yml
+++ b/.github/workflows/docker.arvados-cli.RocheCert.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build and publish on Dockerhub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: matmu/arvados-cli
         username: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/docker.arvados-cli.RocheCertConda.yml
+++ b/.github/workflows/docker.arvados-cli.RocheCertConda.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build and publish on Dockerhub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: matmu/arvados-cli
         username: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/docker.arvados-cli.yml
+++ b/.github/workflows/docker.arvados-cli.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build and publish on Dockerhub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: matmu/arvados-cli
         username: ${{ secrets.DOCKER_USER }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore